### PR TITLE
Switch to original MongoDB image, as the old one is not available anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ You can convert the certificate files to \n delimited strings using `sed -z 's/\
 
 | key | comment | optional |
 |-----|---------|----------|
-| `OSEM_dbuser` | the database user to connect to your mongodb, should be the same in services `api`, `mongo`, `ttn-integration` and `mqtt-integration` | y |
-| `OSEM_dbuserpass` | the password for the mongodb user, should be the same in services `api`, `mongo`, `ttn-integration` and `mqtt-integration` | y |
+| `MONGO_INITDB_ROOT_USERNAME` | the database user to connect to your mongodb, should be the same in services `api`, `mongo`, `ttn-integration` and `mqtt-integration` |   |
+| `MONGO_INITDB_ROOT_PASSWORD` | the password for the mongodb user, should be the same in services `api`, `mongo`, `ttn-integration` and `mqtt-integration` |   |
+
+The user will be create in the `admin` database, so the `authsource` parameter needs to be set to `admin` in services `api`, `mongo`, `ttn-integration` and `mqtt-integration`.
 
 ## Service `mailer`
 

--- a/database-services.yml
+++ b/database-services.yml
@@ -5,11 +5,9 @@ services:
     image: mongo:4.0
     volumes:
       - mongo-data:/data/db
-      - ./database-user.js:/docker-entrypoint-initdb.d/001-user.js
     environment:
-      MONGO_INITDB_ROOT_USERNAME: osemadmin
-      MONGO_INITDB_ROOT_PASSWORD: SecretPass
-      MONGO_INITDB_DATABASE: osem-api-db
+      MONGO_INITDB_ROOT_USERNAME: mongodbOSeMUser
+      MONGO_INITDB_ROOT_PASSWORD: securePaSs
     command: --storageEngine wiredTiger
     networks:
       - api-back

--- a/database-services.yml
+++ b/database-services.yml
@@ -2,13 +2,15 @@ version: "2"
 
 services:
   mongo_:
-    image: sensebox/opensensemap-api-mongo
+    image: mongo:4.0
     volumes:
       - mongo-data:/data/db
+      - ./database-user.js:/docker-entrypoint-initdb.d/001-user.js
     environment:
-      OSEM_dbuser: mongodbOSeMUser
-      OSEM_dbuserpass: securePaSs
-    command: --auth --storageEngine wiredTiger
+      MONGO_INITDB_ROOT_USERNAME: osemadmin
+      MONGO_INITDB_ROOT_PASSWORD: SecretPass
+      MONGO_INITDB_DATABASE: osem-api-db
+    command: --storageEngine wiredTiger
     networks:
       - api-back
     restart: always

--- a/database-user.js
+++ b/database-user.js
@@ -1,0 +1,7 @@
+db.createUser(
+   {
+     user: "mongodbOSeMUser",
+     pwd: "securePaSs",
+     roles: [ "readWrite", "dbAdmin" ]
+   }
+)

--- a/database-user.js
+++ b/database-user.js
@@ -1,7 +1,0 @@
-db.createUser(
-   {
-     user: "mongodbOSeMUser",
-     pwd: "securePaSs",
-     roles: [ "readWrite", "dbAdmin" ]
-   }
-)


### PR DESCRIPTION
The `sensebox/opensensemap-api-mongo` container image is not available.

Instead, the original MongoDB image could be used. OSeM requires a user to be setup in the OSeM API database, so that is created using a startup script. 